### PR TITLE
Wrapper fun load all

### DIFF
--- a/R/get_from_gh.R
+++ b/R/get_from_gh.R
@@ -1,5 +1,5 @@
 # The objective of all the functions below is to provide a suite of interactive
-# tools to work with github files seamlessly. Ideally, these functions will
+# tools to work with github files or folders seamlessly. Ideally, these functions will
 # fully supersede the functions in load_from_gh.R
 
 
@@ -183,13 +183,13 @@ load_from_disk <- function(temp_file, ...) {
 }
 
 
-#' Get info of a file in a Github repo
+#' Get info of a file or files within a folder in a Github repo
 #'
 #'
 #' @param owner character: owner of repo
 #' @param repo character: repository name
-#' @param file_path character: file path
-#' @param branch character: branch where the file is
+#' @param file_path character: file or folder path
+#' @param branch character: branch where the file or folder is
 #'
 #' @return Complete response from GET method of Github API
 #' @export
@@ -199,6 +199,11 @@ load_from_disk <- function(temp_file, ...) {
 #'                       repo      = "pip_info",
 #'                       file_path = "releases.csv",
 #'                       branch    = "releases")
+#'
+#' get_file_info_from_gh(owner     = getOption("pipfun.ghowner"),
+#'                       repo      = "pipfaker",
+#'                       file_path = "data/20240627_2017_01_02_PROD/_aux",
+#'                       branch    = "aux_estimations")
 get_file_info_from_gh <- function(owner= getOption("pipfun.ghowner"),
                                   repo,
                                   branch = "main",
@@ -213,7 +218,7 @@ get_file_info_from_gh <- function(owner= getOption("pipfun.ghowner"),
   #        owner = owner, repo = repo, path = path, ref = ref,
   #        .token = Sys.getenv("GITHUB_PAT"))
 
-  gh::gh(
+  gh_info <- gh::gh(
     "GET /repos/{owner}/{repo}/contents/{file_path}",
     owner     = owner,
     repo      = repo,
@@ -221,6 +226,14 @@ get_file_info_from_gh <- function(owner= getOption("pipfun.ghowner"),
     .params   = list(ref = branch),
     .token = creds$password
   )
+
+  # Fix names for folders
+
+  if(is.null(names(gh_info))){
+    names(gh_info) <- lapply(gh_info, function(x) names(x) <- x$name)
+  }
+
+  return(gh_info)
 
 }
 

--- a/R/load_all_from_gh.R
+++ b/R/load_all_from_gh.R
@@ -1,0 +1,51 @@
+#' Get all files from folder in Github
+#'
+#' @inheritParams get_file_info_from_gh
+#' @param folder_path character: folder path
+#' @param output_path character: folder path
+#'
+#' @return file of extension in [path]
+#' @export
+#'
+#' @examples
+#' load_all_from_gh(owner     = getOption("pipfun.ghowner"),
+#'                  repo      = "pipfaker",
+#'                  file_path = "data/20240627_2017_01_02_PROD/_aux",
+#'                  branch    = "aux_estimations")
+load_all_from_gh <- function(owner= getOption("pipfun.ghowner"),
+                                repo,
+                                branch = "main",
+                                folder_path,
+                                output_path) {
+
+
+  # output_path <- "E:/PovcalNet/01.personal/wb535623/PIP/temp"
+  # output_path <- file.path(output_path, "20240627_2017_01_02_PROD","_aux")
+
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # computations   ---------
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  # Fetch the content metadata using gh, with authentication
+
+  metadata <- get_file_info_from_gh(owner     = owner,
+                                    repo      = repo,
+                                    branch    = branch,
+                                    file_path = file_path)
+
+  # Create lists of paths
+
+  urls <- lapply(metadata, function(df) df$url)
+  output_paths <- lapply(as.list(names(urls)),function(base) path <- fs::path(output_path, base))
+
+  # Download all files
+
+  temp_files <- mapply(download_from_gh, urls, output_paths)
+
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # Return   ---------
+  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  return(invisible(temp_files))
+
+}
+

--- a/R/load_all_from_gh.R
+++ b/R/load_all_from_gh.R
@@ -31,7 +31,7 @@ load_all_from_gh <- function(owner= getOption("pipfun.ghowner"),
   metadata <- get_file_info_from_gh(owner     = owner,
                                     repo      = repo,
                                     branch    = branch,
-                                    file_path = file_path)
+                                    file_path = folder_path)
 
   # Create lists of paths
 


### PR DESCRIPTION
1. Changes in description of `get_file_info_from_gh` to include folders and inside the function to name lists within the list when file_path is a folder (Question: should we change the name of the function?
2. New function load_all_from_gh to load all files from a folder in GH, which is a wrapper for `download_from_gh` and uses `get_file_info_from_gh` for metadata (Question: should we add the function to the get_from_gh.R file or keep it as a new file as it is?)